### PR TITLE
add url and filename parameter for downloading eclipse

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,7 +12,9 @@ class eclipse (
   $service_release = 'SR1',
   $method          = 'package',
   $owner_group     = undef,
-  $ensure          = present
+  $ensure          = present,
+  $url             = undef,
+  $filename        = undef
 ) {
 
   include eclipse::params
@@ -26,7 +28,9 @@ class eclipse (
         release_name    => $release_name,
         service_release => $service_release,
         owner_group     => $owner_group,
-        ensure          => $ensure
+        ensure          => $ensure,
+        url             => $url,
+        filename        => $filename
       }
       $bin = $eclipse::params::download_bin
     }


### PR DESCRIPTION
Hi,

I have added two additional parameters for installing the newest eclipse release "Mars".
With these parameters the manifest does not need to be changed when the naming pattern for the download files change, because the file name and URL can be given from the outside.

Greetings,
Sascha
